### PR TITLE
clear thumbnails before generating new ones

### DIFF
--- a/thumb_pdf.py
+++ b/thumb_pdf.py
@@ -5,8 +5,8 @@
 import os
 import os.path
 
-os.system('mkdir -p static')
 os.system('mkdir -p static/thumbs')
+os.system('rm static/thumbs/*')
 
 relpath = "pdf"
 allFiles = os.listdir(relpath)


### PR DESCRIPTION
I didn't have a chance to make sure this doesn't break anything :)

Right now if you search for "[body](https://karpathy23-5000.terminal.com/search?q=body)" then "[music](https://karpathy23-5000.terminal.com/search?q=music)" you can see some leftover thumbnails from the top result for "body" in the top result for "music" because it has less than 7 pages.

Body:

![1511 05904v1 pdf](https://cloud.githubusercontent.com/assets/157106/11451349/3d7a757e-95c3-11e5-8a8c-e4f432bfb4ef.jpg)

Music:

![1511 05520v1 pdf](https://cloud.githubusercontent.com/assets/157106/11451350/44c5ca40-95c3-11e5-877d-fcc025996939.jpg)

I also removed the first `mkdir -p`, because the command operates recursively so only the second one is needed.