### PR TITLE
cv.[CV|CL|LG] -> cs.[CV|CL|LG]

### DIFF
--- a/templates/main.html
+++ b/templates/main.html
@@ -247,7 +247,7 @@ $(document).ready(function(){
 <div id ="titdiv">
 <h1>Arxiv Sanity Preserver</h1>
 Because things are seriously getting out of hand.<br>
-Serving last {{ numpapers }} papers from cv.[CV|CL|LG]
+Serving last {{ numpapers }} papers from cs.[CV|CL|LG]
 </div>
 
 <div id="sbox">


### PR DESCRIPTION
Fixing what I believe is a typo in the header.