### PR TITLE
css style fix, page width slightly exceeds window width

### DIFF
--- a/templates/main.html
+++ b/templates/main.html
@@ -61,7 +61,7 @@ h1 {
 	margin: 0;
 }
 #titdiv {
-	width: 100%;
+	width: auto;
 	height: 70px;
 	background-color: #840000;
 	color: white;


### PR DESCRIPTION
Noticed that there was a small horizontal scroll present while browsing your website, caused by `padding-left` of `#titdiv`. In case that's still relevant, I think this should fix it.

Before:
![screen shot 2015-12-10 at 9 46 08 pm](https://cloud.githubusercontent.com/assets/744929/11736907/50e28e5c-9f88-11e5-973f-7acc180dc140.png)

After:
![screen shot 2015-12-10 at 9 46 26 pm](https://cloud.githubusercontent.com/assets/744929/11736908/5445021e-9f88-11e5-8e41-7f8fab04b0ed.png)
