### PR TITLE
Overwrite the databases atomically

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -11,6 +11,8 @@ import os
 import random
 import numpy as np
 
+import utils
+
 # read database
 db = pickle.load(open('db.p', 'rb'))
 
@@ -47,7 +49,7 @@ print X.shape
 out = {}
 out['X'] = X # this one is heavy!
 print('writing tfidf.p')
-pickle.dump(out, open("tfidf.p", "wb"), -1)
+utils.safe_pickle_dump(out, "tfidf.p")
 
 # writing lighter metadata information into a separate (smaller) file
 out = {}
@@ -56,7 +58,7 @@ out['idf'] = v._tfidf.idf_
 out['pids'] = pids # a full idvv string (id and version number)
 out['ptoi'] = { x:i for i,x in enumerate(pids) } # pid to ix in X mapping
 print('writing tfidf_meta.p')
-pickle.dump(out, open("tfidf_meta.p", "wb"), -1)
+utils.safe_pickle_dump(out, "tfidf_meta.p")
 
 print 'precomputing nearest neighbor queries in batches...'
 X = X.todense() # originally it's a sparse matrix
@@ -72,4 +74,4 @@ for i in xrange(0,len(pids),batch_size):
   print '%d/%d...' % (i, len(pids))
 
 print('writing sim_dict.p')
-pickle.dump(sim_dict, open("sim_dict.p", "wb"), -1)
+utils.safe_pickle_dump(sim_dict, "sim_dict.p")

--- a/buildsvm.py
+++ b/buildsvm.py
@@ -10,6 +10,8 @@ import re
 import os
 from sklearn import svm
 
+import utils
+
 DATABASE = 'as.db'
 sqldb = sqlite3.connect(DATABASE)
 sqldb.row_factory = sqlite3.Row # to return dicts rather than tuples
@@ -63,4 +65,4 @@ for ii,u in enumerate(users):
   user_sim[uid] = [strip_version(meta['pids'][ix]) for ix in list(sortix)]
 
 print 'writing user_sim.p'
-pickle.dump(user_sim, open("user_sim.p", "wb"))
+utils.safe_pickle_dump(user_sim, "user_sim.p")

--- a/fetch_papers.py
+++ b/fetch_papers.py
@@ -11,6 +11,7 @@ import os
 import cPickle as pickle
 import argparse
 import random
+import utils
 
 def encode_feedparser_dict(d):
   """ 
@@ -116,4 +117,4 @@ if __name__ == "__main__":
 
   # save the database before we quit
   print 'saving database with %d papers to %s' % (len(db), args.db_path)
-  pickle.dump(db, open(args.db_path, 'wb'), -1)
+  utils.safe_pickle_dump(db, args.db_path)

--- a/serve.py
+++ b/serve.py
@@ -13,6 +13,7 @@ import argparse
 from random import shuffle
 import re
 import os
+import utils
 
 # database configuration
 DATABASE = 'as.db'
@@ -472,7 +473,7 @@ if __name__ == "__main__":
       SEARCH_DICT[pid] = merge_dicts([dict_title, dict_authors, dict_categories, dict_summary])
     # and cache it in file
     print 'writing search_dict.p as cache'
-    pickle.dump(SEARCH_DICT, open('search_dict.p', 'wb'), -1)
+    utils.safe_pickle_dump(SEARCH_DICT, 'search_dict.p')
   else:
     print 'loading cached index for faster search...'
     SEARCH_DICT = pickle.load(open('search_dict.p', 'rb'))

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,64 @@
+from contextlib import contextmanager
+
+import tempfile
+import os
+import cPickle as pickle
+
+# Context managers for atomic writes courtesy of
+# http://stackoverflow.com/questions/2333872/atomic-writing-to-file-with-python
+@contextmanager
+def _tempfile(*args, **kws):
+    """ Context for temporary file.
+
+    Will find a free temporary filename upon entering
+    and will try to delete the file on leaving
+
+    Parameters
+    ----------
+    suffix : string
+        optional file suffix
+    """
+
+    fd, name = tempfile.mkstemp(*args, **kws)
+    os.close(fd)
+    try:
+        yield name
+    finally:
+        try:
+            os.remove(name)
+        except OSError as e:
+            if e.errno == 2:
+                pass
+            else:
+                raise e
+
+
+@contextmanager
+def open_atomic(filepath, *args, **kwargs):
+    """ Open temporary file object that atomically moves to destination upon
+    exiting.
+
+    Allows reading and writing to and from the same filename.
+
+    Parameters
+    ----------
+    filepath : string
+        the file path to be opened
+    fsync : bool
+        whether to force write the file to disk
+    kwargs : mixed
+        Any valid keyword arguments for :code:`open`
+    """
+    fsync = kwargs.pop('fsync', False)
+
+    with _tempfile(dir=os.path.dirname(filepath)) as tmppath:
+        with open(tmppath, *args, **kwargs) as f:
+            yield f
+            if fsync:
+                f.flush()
+                os.fsync(file.fileno())
+        os.rename(tmppath, filepath)
+
+def safe_pickle_dump(obj, fname):
+    with open_atomic(fname, 'wb') as f:
+        pickle.dump(obj, f, -1)


### PR DESCRIPTION
Previously, a poorly-timed C-c could cause you to lose the database of papers if it happens in the middle of pickle.dump.