### PR TITLE
Make codebase python3 compatible;

### DIFF
--- a/analyze.py
+++ b/analyze.py
@@ -2,9 +2,14 @@
 Reads txt files of all papers and computes tfidf vectors for all papers.
 Dumps results to file tfidf.p
 """
+from __future__ import print_function
+
 from sklearn.feature_extraction.text import TfidfVectorizer
-import cPickle as pickle
-import urllib2
+try:
+  import pickle as pickle
+except:
+  import cPickle as pickle
+
 import shutil
 import time
 import os
@@ -20,7 +25,7 @@ db = pickle.load(open('db.p', 'rb'))
 txts = []
 pids = []
 n=0
-for pid,j in db.iteritems():
+for pid,j in db.items():
   n+=1
   idvv = '%sv%d' % (j['_rawid'], j['_version'])
   fname = os.path.join('txt', idvv) + '.pdf.txt'
@@ -29,9 +34,9 @@ for pid,j in db.iteritems():
     if len(txt) > 100: # way too short and suspicious
       txts.append(txt) # todo later: maybe filter or something some of them
       pids.append(idvv)
-      print 'read %d/%d (%s) with %d chars' % (n, len(db), idvv, len(txt))
+      print('read %d/%d (%s) with %d chars' % (n, len(db), idvv, len(txt)))
     else:
-      print 'skipped %d/%d (%s) with %d chars: suspicious!' % (n, len(db), idvv, len(txt))
+      print('skipped %d/%d (%s) with %d chars: suspicious!' % (n, len(db), idvv, len(txt)))
 
 # compute tfidf vectors with scikits
 v = TfidfVectorizer(input='content', 
@@ -42,8 +47,8 @@ v = TfidfVectorizer(input='content',
         norm='l2', use_idf=True, smooth_idf=True, sublinear_tf=False)
 
 X = v.fit_transform(txts)
-print v.vocabulary_
-print X.shape
+print(v.vocabulary_)
+print(X.shape)
 
 # write full matrix out
 out = {}
@@ -60,18 +65,18 @@ out['ptoi'] = { x:i for i,x in enumerate(pids) } # pid to ix in X mapping
 print('writing tfidf_meta.p')
 utils.safe_pickle_dump(out, "tfidf_meta.p")
 
-print 'precomputing nearest neighbor queries in batches...'
+print('precomputing nearest neighbor queries in batches...')
 X = X.todense() # originally it's a sparse matrix
 sim_dict = {}
 batch_size = 200
-for i in xrange(0,len(pids),batch_size):
+for i in range(0,len(pids),batch_size):
   i1 = min(len(pids), i+batch_size)
   xquery = X[i:i1] # BxD
   ds = -np.asarray(np.dot(X, xquery.T)) #NxD * DxB => NxB
   IX = np.argsort(ds, axis=0) # NxB
-  for j in xrange(i1-i):
+  for j in range(i1-i):
     sim_dict[pids[i+j]] = [pids[q] for q in list(IX[:50,j])]
-  print '%d/%d...' % (i, len(pids))
+  print('%d/%d...' % (i, len(pids)))
 
 print('writing sim_dict.p')
 utils.safe_pickle_dump(sim_dict, "sim_dict.p")

--- a/buildsvm.py
+++ b/buildsvm.py
@@ -1,5 +1,12 @@
+from __future__ import print_function
+
 from sqlite3 import dbapi2 as sqlite3
-import cPickle as pickle
+
+try:
+  import pickle as pickle
+except:
+  import cPickle as pickle
+
 import numpy as np
 import json
 import time
@@ -24,8 +31,8 @@ def query_db(query, args=(), one=False):
 
 users = query_db('''select * from user''')
 for u in users:
-  print u
-print 'number of users: ', len(users)
+  print(u)
+print('number of users: ', len(users))
 
 def strip_version(idstr):
   """ identity function if arxiv id has no version, otherwise strips it. """
@@ -38,11 +45,11 @@ out = pickle.load(open("tfidf.p", "rb"))
 X = out['X']
 X = X.todense()
 
-xtoi = { strip_version(x):i for x,i in meta['ptoi'].iteritems() }
+xtoi = { strip_version(x):i for x,i in meta['ptoi'].items() }
 
 user_sim = {}
 for ii,u in enumerate(users):
-  print '%d/%d building an SVM for %s' % (ii, len(users), u['username'].encode('utf-8'))
+  print('%d/%d building an SVM for %s' % (ii, len(users), u['username'].encode('utf-8')))
   uid = u['user_id']
   lib = query_db('''select * from library where user_id = ?''', [uid])
   pids = [x['paper_id'] for x in lib] # raw pids without version
@@ -51,7 +58,7 @@ for ii,u in enumerate(users):
   if not posix:
     continue # empty library for this user maybe?
 
-  print pids
+  print(pids)
   y = np.zeros(X.shape[0])
   for ix in posix:
     y[ix] = 1
@@ -64,5 +71,5 @@ for ii,u in enumerate(users):
   sortix = np.argsort(-s)
   user_sim[uid] = [strip_version(meta['pids'][ix]) for ix in list(sortix)]
 
-print 'writing user_sim.p'
+print('writing user_sim.p')
 utils.safe_pickle_dump(user_sim, "user_sim.p")

--- a/download_pdfs.py
+++ b/download_pdfs.py
@@ -1,41 +1,62 @@
-import cPickle as pickle
-import urllib2
+from __future__ import print_function
+
+try:
+  from urllib.parse import urlparse, urlencode
+  from urllib.request import urlopen, Request
+  from urllib.error import HTTPError
+except ImportError:
+  from urlparse import urlparse
+  from urllib import urlencode
+  from urllib2 import urlopen, Request, HTTPError
+
+try:
+  import pickle as pickle
+except:
+  import cPickle as pickle
+
 import shutil
 import time
 import os
 import random
 
-os.system('mkdir -p pdf') # ?
+def download_pdf(paper_timeout=10,#after this many seconds we give up on a paper
+                 database_file='db.p',#database file
+                 out_dir='pdf'):
+  os.system('mkdir -p pdf') # ?
+  timeout_secs = paper_timeout # after this many seconds we give up on a paper
+  numok = 0
+  numtot = 0
+  db = pickle.load(open(database_file, 'rb'))
+  have = set(os.listdir(out_dir)) # get list of all pdfs we already have
+  for pid,j in db.items():
+    pdfs = [x['href'] for x in j['links'] if x['type'] == 'application/pdf']
+    assert len(pdfs) == 1
+    pdf_url = pdfs[0] + '.pdf'
+    basename = pdf_url.split('/')[-1]
+    fname = os.path.join(out_dir, basename)
 
-timeout_secs = 10 # after this many seconds we give up on a paper
-numok = 0
-numtot = 0
-db = pickle.load(open('db.p', 'rb'))
-have = set(os.listdir('pdf')) # get list of all pdfs we already have
-for pid,j in db.iteritems():
-  
-  pdfs = [x['href'] for x in j['links'] if x['type'] == 'application/pdf']
-  assert len(pdfs) == 1
-  pdf_url = pdfs[0] + '.pdf'
-  basename = pdf_url.split('/')[-1]
-  fname = os.path.join('pdf', basename)
+    # try retrieve the pdf
+    numtot += 1
+    try:
+      if not basename in have:
+        print('fetching %s into %s' % (pdf_url, fname))
+        req = urlopen(pdf_url, None, timeout_secs)
+        with open(fname, 'wb') as fp:
+            shutil.copyfileobj(req, fp)
+        time.sleep(0.1 + random.uniform(0,0.2))
+      else:
+        print('%s exists, skipping' % (fname, ))
+      numok += 1
+    except Exception as e:
+      print('error downloading: ', pdf_url)
+      print(e)
+    print('%d/%d of %d downloaded ok.' % (numok, numtot, len(db)))
+  print('final number of papers downloaded okay: %d/%d' % (numok, len(db)))
+  return numok, db
 
-  # try retrieve the pdf
-  numtot += 1
-  try:
-    if not basename in have:
-      print 'fetching %s into %s' % (pdf_url, fname)
-      req = urllib2.urlopen(pdf_url, None, timeout_secs)
-      with open(fname, 'wb') as fp:
-          shutil.copyfileobj(req, fp)
-      time.sleep(0.1 + random.uniform(0,0.2))
-    else:
-      print '%s exists, skipping' % (fname, )
-    numok+=1
-  except Exception, e:
-    print 'error downloading: ', pdf_url
-    print e
-  
-  print '%d/%d of %d downloaded ok.' % (numok, numtot, len(db))
-  
-print 'final number of papers downloaded okay: %d/%d' % (numok, len(db))
+def main():
+  print("Starting to download PDFs")
+  download_pdf()
+
+if __name__ == '__main__':
+  main()

--- a/parse_pdf_to_text.py
+++ b/parse_pdf_to_text.py
@@ -4,32 +4,49 @@ and create a file txt/f.pdf.txt that contains the raw text, extracted
 using the "pdftotext" command. If a pdf cannot be converted, this
 script will not produce the output file.
 """
+from __future__ import print_function
 
-import cPickle as pickle
-import urllib2
+try:
+  import pickle as pickle
+except:
+  import cPickle as pickle
+
 import shutil
 import time
 import os
 import random
 
-os.system('mkdir -p txt') # ?
+def extract_text(in_dir = 'pdf', out_dir = 'txt'):
+  list_of_failures = []
 
-have = set(os.listdir('txt'))
-files = os.listdir('pdf')
-for i,f in enumerate(files, start=1):
-  pdf_path = os.path.join('pdf', f)
-  txt_basename = f + '.txt'
-  txt_path = os.path.join('txt', txt_basename)
-  if not txt_basename in have:
-    cmd = "pdftotext %s %s" % (pdf_path, txt_path)
-    os.system(cmd)
-    print '%d/%d %s' % (i, len(files), cmd)
+  os.system('mkdir -p %s' % (out_dir)) # ?
+  have = set(os.listdir(out_dir))
+  files = os.listdir(in_dir)
+  for i,f in enumerate(files, start=1):
+    pdf_path = os.path.join(in_dir, f)
+    txt_basename = f + '.txt'
+    txt_path = os.path.join(out_dir, txt_basename)
+    if not txt_basename in have:
+      cmd = "pdftotext %s %s" % (pdf_path, txt_path)
+      os.system(cmd)
+      print('%d/%d %s' % (i, len(files), cmd))
 
-    # check output was made
-    if not os.path.isfile(txt_path):
-      # there was an error with converting the pdf
-      os.system('touch ' + txt_path) # create empty file, but it's a record of having tried to convert
+      # check output was made
+      if not os.path.isfile(txt_path):
+        # there was an error with converting the pdf
+        print("Error with file: ", f)
+        list_of_failures.append(f)
+        os.system('touch ' + txt_path) # create empty file, but it's a record of having tried to convert
 
-    time.sleep(0.02) # silly way for allowing for ctrl+c termination
-  else:
-    print 'skipping %s, already exists.' % (pdf_path, )
+      time.sleep(0.02) # silly way for allowing for ctrl+c termination
+    else:
+      print('skipping %s, already exists.' % (pdf_path, ))
+  return list_of_failures
+
+def main():
+  list_of_failures = extract_text()
+  for fail in list_of_failures:
+    print("File %s Failed." % fail)
+
+if __name__ == '__main__':
+  main()

--- a/thumb_pdf.py
+++ b/thumb_pdf.py
@@ -1,6 +1,7 @@
 # use imagemagick to convert 
 # them all to a sequence of thumbnail images
 # requires sudo apt-get install imagemagick
+from __future__ import print_function
 
 import os
 import os.path
@@ -19,10 +20,10 @@ for i,p in enumerate(pdfs):
   outpath = os.path.join('static', 'thumbs', p + '.jpg')
 
   if os.path.isfile(outpath): 
-    print 'skipping %s, exists.' % (fullpath, )
+    print('skipping %s, exists.' % (fullpath, ))
     continue
 
-  print "%d/%d processing %s" % (i, len(pdfs), p)
+  print("%d/%d processing %s" % (i, len(pdfs), p))
 
   # take first 8 pages of the pdf ([0-7]), since 9th page are references
   # tile them horizontally, use JPEG compression 80, trim the borders for each image
@@ -35,7 +36,7 @@ for i,p in enumerate(pdfs):
 
   # erase previous intermediate files test-*.png
   if os.path.isfile('tmp/test-0.png'):
-    for i in xrange(8):
+    for i in range(8):
       f = 'tmp/test-%d.png' % (i,)
       f2= 'tmp/testbuf-%d.png' % (i,)
       if os.path.isfile(f):
@@ -64,10 +65,10 @@ for i,p in enumerate(pdfs):
   if not os.path.isfile('tmp/test-0.png'):
     # failed to render pdf, replace with missing image
     os.system('cp %s %s' % ('static/thumbs/missing.jpg', outpath))
-    print 'could not render pdf, creating a missing image placeholder'
+    print('could not render pdf, creating a missing image placeholder')
   else:
     cmd = "montage -mode concatenate -quality 80 -tile x1 tmp/test-*.png %s" % (outpath, )
-    print cmd
+    print(cmd)
     os.system(cmd)
 
   time.sleep(0.01) # silly way for allowing for ctrl+c termination

--- a/utils.py
+++ b/utils.py
@@ -1,8 +1,13 @@
+from __future__ import print_function
+
 from contextlib import contextmanager
 
 import tempfile
 import os
-import cPickle as pickle
+try:
+  import pickle as pickle
+except:
+  import cPickle as pickle
 
 # Context managers for atomic writes courtesy of
 # http://stackoverflow.com/questions/2333872/atomic-writing-to-file-with-python


### PR DESCRIPTION
Currently the arxiv-sanity-preserver is not python3 compatible. This pull request does the following:

(1) reworks imports for `urllib` and `pickle`;
(2) convert to `print_function` (`from __future__ import print_function`);
(3) switch from `iteritems()` and `iterkeys()` in favor of `items()` and `keys()`;
(4) starting to wrap functionality of various scripts into functions to remove dependencies on magic value (currently reworked `download_pdfs.py` - to allow for specifying the timeout, database file and output directory);

With these changes I believe this should allow python3 to be used to run the code (note: pickling will have to be reworked - if you want to use python3 after running in python2).