### PR TITLE
Use local URL variable instead of the global one

### DIFF
--- a/fetch_papers.py
+++ b/fetch_papers.py
@@ -38,7 +38,7 @@ def parse_arxiv_url(url):
   we want to extract the raw id and the version
   """
   ix = url.rfind('/')
-  idversion = j['id'][ix+1:] # extract just the id (and the version)
+  idversion = url[ix+1:] # extract just the id (and the version)
   parts = idversion.split('v')
   assert len(parts) == 2, 'error parsing url ' + url
   return parts[0], int(parts[1])


### PR DESCRIPTION
Fixes a small c/p error