### PR TITLE
mathjax cdn shutting down, pointing to cloudflare instead

### DIFF
--- a/templates/discuss.html
+++ b/templates/discuss.html
@@ -10,7 +10,7 @@
   MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
 </script>
 <script type="text/javascript" async
-  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML">
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_CHTML">
 </script>
 
 <!-- CSS -->

--- a/templates/main.html
+++ b/templates/main.html
@@ -10,7 +10,7 @@
   MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
 </script>
 <script type="text/javascript" async
-  src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML">
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_CHTML">
 </script>
 
 <!-- CSS -->


### PR DESCRIPTION
MathJax's CDN is shutting down.  I changed the URLs to point to the copy hosted by CloudFlare recommended by the MJ folks.

See this page:
https://www.mathjax.org/cdn-shutting-down/