### PR TITLE
Fix Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You will also need [ImageMagick](http://www.imagemagick.org/script/index.php) an
 
 The processing pipeline requires you to run a series of scripts, and at this stage I really encourage you to manually inspect each script, as they may contain various inline settings you might want to change. In order, the processing pipeline is:
 
-1. Run `fetch_papers.py` to query arxiv API and create a file `db.p` that contains all information for each paper. This script is where you would modify the **query**, indicating which parts of arxiv you'd like to use. Note that if you're trying to pull too many papers arxiv will start to rate limit you. You may have to run the script multiple times, and I recommend using the arg `--start_index` to restart where you left off when you were last interrupted by arxiv.
+1. Run `fetch_papers.py` to query arxiv API and create a file `db.p` that contains all information for each paper. This script is where you would modify the **query**, indicating which parts of arxiv you'd like to use. Note that if you're trying to pull too many papers arxiv will start to rate limit you. You may have to run the script multiple times, and I recommend using the arg `--start-index` to restart where you left off when you were last interrupted by arxiv.
 2. Run `download_pdfs.py`, which iterates over all papers in parsed pickle and downloads the papers into folder `pdf`
 3. Run `parse_pdf_to_text.py` to export all text from pdfs to files in `txt`
 4. Run `thumb_pdf.py` to export thumbnails of all pdfs to `thumb`


### PR DESCRIPTION
Changed `--start_index` to `--start-index` for `fetch_papers.py`, in README under the [Processing Pipeline](https://github.com/karpathy/arxiv-sanity-preserver#processing-pipeline) heading.