### PR TITLE
Adds a Dockerfile that builds an image with all required dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python
+RUN    apt-get update \
+    && apt-get install -y nano imagemagick ghostscript poppler-utils sqlite3 libsqlite3-dev
+ADD . /code
+WORKDIR /code
+RUN pip install -r requirements.txt


### PR DESCRIPTION
This is a Dockerfile to build an image with all required dependencies. We use this on to deploy the high energy physics version of arxiv-sanity at CERN