### PR TITLE
accept paper IDs without a dot

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -98,4 +98,4 @@ def strip_version(idstr):
 
 # "1511.08198v1" is an example of a valid arxiv id that we accept
 def isvalidid(pid):
-  return re.match('^\d+\.\d+(v\d+)?$', pid)
+  return re.match('^\d+(v\d+)?$', pid)


### PR DESCRIPTION
For example 0401304v1 is a valid ID of one the papers for cond-mat. It was downloaded among first articles for condensed matter physics category. (btw, ´--search-query 'cat:physics:cond-mat'´ did not work and I hardcoded 'cat:cond-mat' into the fetch_papers.py)
https://arxiv.org/pdf/cond-mat/0401304v1.pdf

As a result it is impossible to add the articles to the personal library. The icon is inactive (the JS UI gets 'NO' as a server response all the time because article ID doesn't pass validation)
https://github.com/karpathy/arxiv-sanity-preserver/issues/134