### PR TITLE
Fix: Import error with Werkzeug

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -12,7 +12,7 @@ from hashlib import md5
 from flask import Flask, request, session, url_for, redirect, \
      render_template, abort, g, flash, _app_ctx_stack
 from flask_limiter import Limiter
-from werkzeug import check_password_hash, generate_password_hash
+from werkzeug.security import check_password_hash, generate_password_hash
 import pymongo
 
 from utils import safe_pickle_dump, strip_version, isvalidid, Config


### PR DESCRIPTION
Saw an import error with 
`from werkzeug import check_password_hash, generate_password_hash`

Turns out the location of the module is (now)
`from werkzeug.security import check_password_hash, generate_password_hash`